### PR TITLE
Sample configuration correction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ an endpoint that supports TLS.
     Match         *
     Addr          logs.papertrailapp.com:18271
     Namespace     myns
-    TLSConfig     {"insecure_skip_verify":"true"}
+    TLSConfig     {"insecure_skip_verify":true}
 
 [OUTPUT]
     Name          syslog


### PR DESCRIPTION
The sample config  `"insecure_skip_verify":"true"`   is not correct for json marshal in go language.

`2019/07/10 04:11:30 [out_syslog] ERROR: Unable to unmarshal TLS config: json: cannot unmarshal string into Go struct field TLS.insecure_skip_verify of type bool`

` "insecure_skip_verify":true`  should be the correct one.